### PR TITLE
Generate unique version numbers in 'check' step

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -6,4 +6,4 @@ set -e -u
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
-jq -n "[ { \"random\": \"${RANDOM}\" } ]" >&3
+jq -n "[ { \"random\": \"$(date +%Y%m%d%H%M%S)-${RANDOM}\" } ]" >&3


### PR DESCRIPTION
We noticed an issue with the use of `${RANDOM}` within the check step for generating version numbers.

Concourse caches versions that it has seen before so that it know not to re-trigger jobs with the versions which have already been used. This works brilliantly for things like git commit IDs which are always unique, but in the case of $RANDOM there are are only 32768 possible version numbers. 

The default `check-every` interval in concourse is 2 mins, meaning that this resource quickly starts to emit random version numbers which have been used before. When a version number which has been used before is emitted, concourse ignores it. This results in pipeline steps receiving the incorrect data which happened on earlier pipeline runs.

This PR implements truly unique version numbers by prefixing ${RANDOM} with with a date/time stamp. 
